### PR TITLE
Dbatiste/api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ Alerts can be defined using `d2l-alert`.
 ```html
 <link rel="import" href="../d2l-alert/d2l-alert.html">
 
-<d2l-alert type='confirmation'>
+<d2l-alert type='call-to-action'>
     This is the alert message
 </d2l-alert>
 
-<d2l-alert type='confirmation' button-text='Yes, use the cool new UI!' has-close-button>
+<d2l-alert type='call-to-action' button-text='Yes, use the cool new UI!' has-close-button>
     This is the alert message
 </d2l-alert>
 ```
 
-* `type` - required to style the alert; values: call-to-action, confirmation, error, warning
+* `type` - required to style the alert; values: call-to-action, success, error, warning
 * `button-text` - optionally specify text for a custom button
 * `has-close-button` - optionally show a close button for dismissing the alert
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Alerts can be defined using `d2l-alert`.
 </d2l-alert>
 ```
 
-* `type` - required to style the alert; values: call-to-action, confirmation, error, warning, or reinforcement
+* `type` - required to style the alert; values: call-to-action, confirmation, error, warning
 * `button-text` - optionally specify text for a custom button
 * `has-close-button` - optionally show a close button for dismissing the alert
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,25 @@ Alerts can be defined using `d2l-alert`.
 <d2l-alert type='confirmation'>
     This is the alert message
 </d2l-alert>
+
+<d2l-alert type='confirmation' button-text='Yes, use the cool new UI!' has-close-button>
+    This is the alert message
+</d2l-alert>
 ```
 
-* `type` - call-to-action(default), confirmation, error, warning, or reinforcement
+* `type` - required to style the alert; values: call-to-action, confirmation, error, warning, or reinforcement
+* `button-text` - optionally specify text for a custom button
+* `has-close-button` - optionally show a close button for dismissing the alert
+
+```javascript
+alert.addEventListener('d2l-alert-button-pressed', function() {
+	console.log('alert custom button pressed!');
+});
+
+alert.addEventListener('d2l-alert-closed', function() {
+	console.log('alert was dismissed/closed');
+});
+```
 
 ### Usage in Production
 

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "d2l-button": "^3.0.8",
     "d2l-colors": "^2.2.3",
     "d2l-icons": "^3.1.0",
+    "d2l-localize-behavior": "^1.0.0",
     "d2l-typography": "^5.3.0"
   },
   "devDependencies": {

--- a/d2l-alert-shared-styles.html
+++ b/d2l-alert-shared-styles.html
@@ -8,7 +8,6 @@
 			--d2l-alert-warning-color: var(--d2l-color-citrine);
 			--d2l-alert-call-to-action-color: var(--d2l-color-celestine-plus-1);
 			--d2l-alert-confirmation-color: var(--d2l-color-olivine);
-			--d2l-alert-reinforcement-color: var(--d2l-color-galena);
 
 		}
 	</style>

--- a/d2l-alert-shared-styles.html
+++ b/d2l-alert-shared-styles.html
@@ -7,7 +7,7 @@
 			--d2l-alert-error-color: var(--d2l-color-cinnabar);
 			--d2l-alert-warning-color: var(--d2l-color-citrine);
 			--d2l-alert-call-to-action-color: var(--d2l-color-celestine-plus-1);
-			--d2l-alert-confirmation-color: var(--d2l-color-olivine);
+			--d2l-alert-success-color: var(--d2l-color-olivine);
 
 		}
 	</style>

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../d2l-icons/tier1-icons.html">
 <link rel="import" href="../d2l-button/d2l-button.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="localize-behavior.html">
 
 <dom-module id="d2l-alert">
 	<template>
@@ -14,6 +15,9 @@
 				display: flex;
 				flex-direction: row;
 				background: white;
+			}
+			:host[hidden] {
+				display: none;
 			}
 			.alert-wrapper {
 				display: flex;
@@ -132,12 +136,12 @@
 				<div class="message-highlight"></div>
 				<slot></slot>
 			</div>
-			<button is="d2l-button" on-tap="_fireAlertButtonPressedEvent" hidden$="[[!hasButton]]">
+			<button is="d2l-button" on-tap="_dispatchButtonPressedEvent" hidden$="[[!hasButton]]">
 				<div class="inner-button d2l-alert-button">
-					[[buttonMessage]]
+					[[buttonText]]
 				</div>
 			</button>
-			<button is="d2l-button" title$="[[closeButtonTitle]]" on-tap="_fireAlertClosedEvent" hidden$="[[!hasCloseButton]]">
+			<button is="d2l-button" title$="[[localize('close')]]" on-tap="close" hidden$="[[!hasCloseButton]]">
 				<div class="inner-button">
 					<d2l-icon class="close-icon" icon="d2l-tier1:close-default"></d2l-icon>
 				</div>
@@ -149,6 +153,11 @@
 
 		Polymer({
 			is: 'd2l-alert',
+
+			behaviors: [
+				window.D2L.PolymerBehaviors.Alert.LocalizeBehavior
+			],
+
 			properties: {
 				type: {
 					type: String,
@@ -157,21 +166,35 @@
 				},
 				hasButton: {
 					type: Boolean,
-					value: false
+					computed: '_computeHasButton(buttonText)'
 				},
-				buttonMessage: String,
+				buttonText: {
+					type: String,
+					value: null
+				},
 				hasCloseButton: {
 					type: Boolean,
 					value: false
-				},
-				closeButtonTitle: String
+				}
 			},
-			_fireAlertClosedEvent: function() {
-				this.fire('alert-closed');
+
+			close: function() {
+				this.setAttribute('hidden', 'hidden');
+				this._dispatchClosedEvent();
 			},
-			_fireAlertButtonPressedEvent: function() {
-				this.fire('alert-button-pressed');
+
+			_computeHasButton: function(buttonText) {
+				return (buttonText && buttonText.length > 0);
+			},
+
+			_dispatchButtonPressedEvent: function() {
+				this.fire('d2l-alert-button-pressed');
+			},
+
+			_dispatchClosedEvent: function() {
+				this.fire('d2l-alert-closed');
 			}
+
 		});
 	</script>
 </dom-module>

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -64,8 +64,8 @@
 			:host([type="call-to-action"]) .message-highlight {
 				background-color: var(--d2l-alert-call-to-action-color);
 			}
-			:host([type="confirmation"]) .message-highlight {
-				background-color: var(--d2l-alert-confirmation-color);
+			:host([type="success"]) .message-highlight {
+				background-color: var(--d2l-alert-success-color);
 			}
 			:host-context([dir='rtl']) .message-highlight {
 				left: auto;

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -64,9 +64,6 @@
 			:host([type="call-to-action"]) .message-highlight {
 				background-color: var(--d2l-alert-call-to-action-color);
 			}
-			:host([type="reinforcement"]) .message-highlight {
-				background-color: var(--d2l-alert-reinforcement-color);
-			}
 			:host([type="confirmation"]) .message-highlight {
 				background-color: var(--d2l-alert-confirmation-color);
 			}

--- a/demo/index.html
+++ b/demo/index.html
@@ -53,7 +53,6 @@
 				<button onclick="showAlert('call-to-action')">Show call-to-action</button>
 				<button onclick="showAlert('confirmation')">Show confirmation</button>
 				<button onclick="showAlert('error')">Show error</button>
-				<button onclick="showAlert('reinforcement')">Show reinforcement</button>
 				<button onclick="showAlert('warning')">Show warning</button>
 			</div>
 
@@ -61,7 +60,6 @@
 				<d2l-alert type="call-to-action">This is a d2l-alert with type="call-to-action". Call-to-action is the default when no type is declared.</d2l-alert>
 				<d2l-alert type="confirmation" hidden>This is a d2l-alert with type="confirmation".</d2l-alert>
 				<d2l-alert type="error" hidden>This is a d2l-alert with type="error".</d2l-alert>
-				<d2l-alert type="reinforcement" hidden>This is a d2l-alert with type="reinforcement".</d2l-alert>
 				<d2l-alert type="warning" hidden>This is a d2l-alert with type="warning".</d2l-alert>
 			</div>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,9 +18,6 @@
 			.flex > d2l-alert {
 				flex: 1 1 auto;
 			}
-			.not-visible {
-				display: none;
-			}
 		</style>
 	</head>
 	<body unresolved class="d2l-typography">
@@ -32,15 +29,24 @@
 				function showAlert(type) {
 					hideAllAlerts();
 					var alert = document.querySelector('d2l-alert[type=' + type + ']');
-					alert.classList.remove('not-visible');
+					alert.removeAttribute('hidden');
 				}
 
 				function hideAllAlerts() {
 					var alerts = document.getElementsByTagName('d2l-alert');
 					for (var i = 0; i < alerts.length; i++) {
-						alerts[i].classList.add('not-visible');
+						alerts[i].setAttribute('hidden', 'hidden');
 					}
 				}
+
+				document.addEventListener('d2l-alert-closed', function(e) {
+					console.log('alert closed');
+				});
+
+				document.addEventListener('d2l-alert-button-pressed', function() {
+					console.log('alert button pressed');
+				});
+
 			</script>
 
 			<div class="buttons">
@@ -53,10 +59,10 @@
 
 			<div class="flex">
 				<d2l-alert type="call-to-action">This is a d2l-alert with type="call-to-action". Call-to-action is the default when no type is declared.</d2l-alert>
-				<d2l-alert type="confirmation" class="not-visible">This is a d2l-alert with type="confirmation".</d2l-alert>
-				<d2l-alert type="error" class="not-visible">This is a d2l-alert with type="error".</d2l-alert>
-				<d2l-alert type="reinforcement" class="not-visible">This is a d2l-alert with type="reinforcement".</d2l-alert>
-				<d2l-alert type="warning" class="not-visible">This is a d2l-alert with type="warning".</d2l-alert>
+				<d2l-alert type="confirmation" hidden>This is a d2l-alert with type="confirmation".</d2l-alert>
+				<d2l-alert type="error" hidden>This is a d2l-alert with type="error".</d2l-alert>
+				<d2l-alert type="reinforcement" hidden>This is a d2l-alert with type="reinforcement".</d2l-alert>
+				<d2l-alert type="warning" hidden>This is a d2l-alert with type="warning".</d2l-alert>
 			</div>
 
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -51,14 +51,14 @@
 
 			<div class="buttons">
 				<button onclick="showAlert('call-to-action')">Show call-to-action</button>
-				<button onclick="showAlert('confirmation')">Show confirmation</button>
+				<button onclick="showAlert('success')">Show success</button>
 				<button onclick="showAlert('error')">Show error</button>
 				<button onclick="showAlert('warning')">Show warning</button>
 			</div>
 
 			<div class="flex">
 				<d2l-alert type="call-to-action">This is a d2l-alert with type="call-to-action". Call-to-action is the default when no type is declared.</d2l-alert>
-				<d2l-alert type="confirmation" hidden>This is a d2l-alert with type="confirmation".</d2l-alert>
+				<d2l-alert type="success" hidden>This is a d2l-alert with type="success".</d2l-alert>
 				<d2l-alert type="error" hidden>This is a d2l-alert with type="error".</d2l-alert>
 				<d2l-alert type="warning" hidden>This is a d2l-alert with type="warning".</d2l-alert>
 			</div>

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -1,0 +1,67 @@
+<link rel="import" href="../d2l-localize-behavior/d2l-localize-behavior.html">
+<script>
+(function() {
+	'use strict';
+
+	/** @polymerBehavior */
+	var AlertLocalizeBehavior = {
+		properties: {
+			resources: {
+				value: function() {
+					return {
+						'en': {
+							'close': 'Close Alert'
+						},
+						'ar': {
+							'close': 'إغلاق التنبيه'
+						},
+						'de': {
+							'close': 'Benachrichtigung schließen'
+						},
+						'es': {
+							'close': 'Alerta de cierre'
+						},
+						'fr': {
+							'close': 'Fermer l\'alerte'
+						},
+						'ja': {
+							'close': 'アラートを閉じる'
+						},
+						'ko': {
+							'close': '경보 닫기'
+						},
+						'nl': {
+							'close': 'Waarschuwing sluiten'
+						},
+						'pt': {
+							'close': 'Fechar Alerta'
+						},
+						'sv': {
+							'close': 'Stängningsvarning'
+						},
+						'tr': {
+							'close': 'Kapatma Uyarısı'
+						},
+						'zh': {
+							'close': '关闭警报'
+						},
+						'zh-tw': {
+							'close': '關閉警示'
+						}
+					};
+				}
+			}
+		}
+	};
+
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.Alert = window.D2L.PolymerBehaviors.Alert || {};
+	/** @polymerBehavior */
+	window.D2L.PolymerBehaviors.Alert.LocalizeBehavior = [
+		D2L.PolymerBehaviors.LocalizeBehavior,
+		AlertLocalizeBehavior
+	];
+
+})();
+</script>


### PR DESCRIPTION
The following API changes are being made to align with BrightspaceUI and design-patterns.  This will require a major version bump, which I will do before hybridizing to enable dependent apps to be updated without requiring hybrid.

* Changed “button-message” to “button-text”
* Changed “alert-closed” event to “d2l-alert-closed”
* Changed “alert-button-pressed” event to “d2l-alert-button-pressed”
* Changed to close alert when close button is pressed
* Change “confirmation” to “success” to align to design patterns
* Removed “close-button-title” since “close” button text is baked into component
* Removed “reinforcement” alert type since it is not part of design patterns and not used
* Removed the requirement to specify “has-button” attribute – it will be computed based on button text
