### PR TITLE
Remove 0.7rem font-size from d2l-alert since default is supposed to b…

### DIFF
--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -11,7 +11,6 @@
 	<template>
 		<style>
 			:host {
-				@apply --d2l-body-small-text;
 				animation: 600ms ease drop-in;
 				display: flex;
 				flex-direction: row;


### PR DESCRIPTION
…e inherited from body text.