### PR TITLE
Toast alerts

### DIFF
--- a/d2l-alert-toast.html
+++ b/d2l-alert-toast.html
@@ -135,7 +135,7 @@ Polymer-based web component for a D2L toast alert
 						requestAnimationFrame(function() {
 							this._toastContainer.classList.add('d2l-alert-toast-container-opened');
 							this._toastContainer.setAttribute('role', 'alert');
-							
+
 							if (this.autoclose === 1) {
 								//clear the setTimeout below that will close after 2.5 seconds if you closed the toast another way, and are re-opening (you'll want a fresh 2.5 seconds)
 								if (this._setTimeoutId > -1) {

--- a/d2l-alert-toast.html
+++ b/d2l-alert-toast.html
@@ -135,20 +135,21 @@ Polymer-based web component for a D2L toast alert
 						requestAnimationFrame(function() {
 							this._toastContainer.classList.add('d2l-alert-toast-container-opened');
 							this._toastContainer.setAttribute('role', 'alert');
+							
+							if (this.autoclose === 1) {
+								//clear the setTimeout below that will close after 2.5 seconds if you closed the toast another way, and are re-opening (you'll want a fresh 2.5 seconds)
+								if (this._setTimeoutId > -1) {
+									clearTimeout(this._setTimeoutId);
+								}
+
+								this._setTimeoutId = setTimeout(function() {
+									this._toastContainer.classList.remove('d2l-alert-toast-container-opened');
+									this._setTimeoutId = -1;
+								}.bind(this), 2500);
+							}
 						}.bind(this));
 					}.bind(this));
 
-					if (this.autoclose === 1) {
-						//clear the setTimeout below that will close after 2.5 seconds if you closed the toast another way, and are re-opening (you'll want a fresh 2.5 seconds)
-						if (this._setTimeoutId > -1) {
-							clearTimeout(this._setTimeoutId);
-						}
-
-						this._setTimeoutId = setTimeout(function() {
-							this._toastContainer.classList.remove('d2l-alert-toast-container-opened');
-							this._setTimeoutId = -1;
-						}.bind(this), 2500);
-					}
 				} else {
 					this._toastContainer.classList.remove('d2l-alert-toast-container-opened');
 					this._toastContainer.removeAttribute('role');


### PR DESCRIPTION
Found an issue while testing the toast with our internet connection detection stuff for quizzing. Didn't know that requestAnimationFrame would pause (or go much slower in FF) when the window was minimized/not focused. Was hitting a problem where the setTimeout was running, and the requestAnimationFrame was not, so the toast was opening but not automatically closing, if the window was minimzed/not focused.

Moving the setTimeout inside the requestAnimationFrame fixed the problem.