### PR TITLE
Allow full-width alert via attribute toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ Subtext can be added underneath the main message heading, if more detail is requ
 </d2l-alert>
 ```
 
+By default the max-width of the alert is 710px, but this can be overridden with the `full-width` attribute.
+
+```html
+<d2l-alert type="default" full-width>
+  A default message that will use all available horizontal space.
+</d2l-alert>
+```
+
 ### Toast Alert
 ```html
 <head>

--- a/d2l-alert.js
+++ b/d2l-alert.js
@@ -34,6 +34,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-alert">
 				width:100%;
 			}
 
+			:host([full-width]) {
+				max-width: unset;
+			}
+
 			:host(.toast) {
 				animation: none;
 			}
@@ -127,7 +131,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-alert">
 			<d2l-button-icon icon="d2l-tier1:close-default" text="[[localize('close')]]" on-tap="close" hidden$="[[!hasCloseButton]]"></d2l-button-icon>
 		</div>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -185,6 +189,13 @@ Polymer({
 		subtext: {
 			type: String,
 			value: null
+		},
+		/**
+		 * Whether to allow the alert to use the full width available, or stay restricted at 710px max-width
+		 */
+		fullWidth: {
+			type: Boolean,
+			value: false
 		}
 	},
 

--- a/demo/alert.html
+++ b/demo/alert.html
@@ -42,6 +42,11 @@ $_documentContainer.innerHTML = `<style>
 			html {
 				font-size: 20px;
 			}
+
+			#wide {
+				width: 150%;
+				margin-left: -25%;
+			}
 		</style>`;
 
 document.body.appendChild($_documentContainer.content);
@@ -80,6 +85,13 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 					<d2l-alert type="warning">A warning message.</d2l-alert>
+				</template>
+			</demo-snippet>
+
+			<h3>Full width</h3>
+			<demo-snippet id="wide">
+				<template>
+					<d2l-alert type="success" full-width>A full-width success message.</d2l-alert>
 				</template>
 			</demo-snippet>
 


### PR DESCRIPTION
In the context of the FACE initiative, there's the requirement to create a variation of `d2l-alert` that will occupy the entire available horizontal width - a full-width alert.

This enables that via the new `full-width` attribute.