### PR TITLE
WCAG 2.1 Color Update

### DIFF
--- a/d2l-alert-shared-styles.js
+++ b/d2l-alert-shared-styles.js
@@ -5,10 +5,10 @@ const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<custom-style>
 	<style is="custom-style">
 		html {
-			--d2l-alert-critical-color: var(--d2l-color-cinnabar);
-			--d2l-alert-warning-color: var(--d2l-color-citrine);
+			--d2l-alert-critical-color: var(--d2l-color-feedback-error);
+			--d2l-alert-warning-color: var(--d2l-color-feedback-warning);
 			--d2l-alert-default-color: var(--d2l-color-celestine-plus-1);
-			--d2l-alert-success-color: var(--d2l-color-olivine);
+			--d2l-alert-success-color: var(--d2l-color-feedback-success);
 		}
 	</style>
 </custom-style>`;


### PR DESCRIPTION
# Changes
- The only actual change here is that the warning color was changed  from citrine to carnelian for WCAG 2.1.  This will keep them aligned in the future.
- This was missed as part of the original WCAG 2.1 update.