### PR TITLE
Fix d2l-alert causing multiple definition errors

### DIFF
--- a/d2l-alert.js
+++ b/d2l-alert.js
@@ -11,8 +11,8 @@ Polymer-based web component for a D2L alert
 */
 import '@polymer/polymer/polymer-legacy.js';
 
-import 'd2l-button/d2l-button-icon.js';
-import 'd2l-button/d2l-button-subtle.js';
+import '@brightspace-ui/core/components/button/button-icon.js';
+import '@brightspace-ui/core/components/button/button-subtle.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import './localize-behavior.js';

--- a/demo/alert-toast.html
+++ b/demo/alert-toast.html
@@ -8,7 +8,7 @@
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
-		<script type="module" src="../../d2l-button/d2l-button.js"></script>
+		<script type="module" src="../../@brightspace-ui/core/components/button/button.js"></script>
 		<script type="module" src="../d2l-alert-toast.js"></script>
 		<!-- FIXME(polymer-modulizer):
 		These imperative modules that innerHTML your HTML are
@@ -92,7 +92,7 @@ document.body.appendChild($_documentContainer.content);
 import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
 import '@polymer/iron-demo-helpers/demo-snippet.js';
 import 'd2l-typography/d2l-typography.js';
-import 'd2l-button/d2l-button.js';
+import '@brightspace-ui/core/components/button/button.js';
 import '../d2l-alert-toast.js';
 document.body.classList.add('d2l-typography');
 document.body.addEventListener('d2l-alert-button-pressed', function() {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "@polymer/polymer": "^3.0.0",
-    "d2l-button": "BrightspaceUI/button#semver:^5",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-typography": "BrightspaceUI/typography#semver:^7"
   }


### PR DESCRIPTION
Fixed d2l-alert importing both the Polymer and Lit versions of d2l-button and d2l-icon, causing errors when used in other components due to multiple definitions of button-related components