### PR TITLE
Synchronize versions in package.json and GitHub releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "polymer-cli": "^1.9.1",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "4.13.2",
+  "version": "4.14.1",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
The latest GitHub release is 4.14.0, but the `package.json` of that release is 4.13, and automatically generated new releases are still being published as version 4.13 since that's what's in `package.json`.

This PR bumps the version up to 4.14.1 to bring it back in sync with the GitHub releases